### PR TITLE
Support models with buffers by default

### DIFF
--- a/src/pytorch.jl
+++ b/src/pytorch.jl
@@ -18,7 +18,9 @@ struct TorchModuleWrapper
     dtype::PyObject
     device::PyObject
     params::Tuple
+    buffers::Tuple
 end
+
 
 Base.show(io::IO, f::TorchModuleWrapper) = print(io, f.torch_stateless_module, " ", f.dtype, " ", f.device, "params size=", size.(f.params))
 
@@ -29,10 +31,10 @@ Base.iterate(f::TorchModuleWrapper, state) = iterate(f.params, state)
 function TorchModuleWrapper(torch_module, device)
     pybuiltin("isinstance")(torch_module, torch.nn.Module) || error("Not a torch.nn.Module")
     torch_module = torch_module.to(device)
-    funmod, params = functorch.make_functional(torch_module)
+    funmod, params, buffers = functorch.make_functional_with_buffers(torch_module)
     dtype = params[1].dtype
     jlparams = map(x -> x.detach().numpy(), params)
-    return TorchModuleWrapper(funmod, dtype, device, jlparams)
+    return TorchModuleWrapper(funmod, dtype, device, jlparams, buffers)
 end
 
 function TorchModuleWrapper(torch_module)
@@ -43,19 +45,19 @@ end
 function (wrap::TorchModuleWrapper)(args...)
     # TODO: handle multiple outputs
     tensor_out = wrap.torch_stateless_module(Tuple(map(x -> torch.as_tensor(x).to(device = wrap.device, dtype = wrap.dtype).requires_grad_(true), wrap.params)),
-        map(x -> torch.as_tensor(PyReverseDims(x)).to(dtype = wrap.dtype, device = wrap.device), args)...)
+        wrap.buffers, map(x -> torch.as_tensor(PyReverseDims(x)).to(dtype = wrap.dtype, device = wrap.device), args)...)
     return reversedims(tensor_out.detach().numpy())
 end
 
 function ChainRulesCore.rrule(wrap::TorchModuleWrapper, args...)
     torch_primal, torch_vjpfun = functorch.vjp(wrap.torch_stateless_module, Tuple(map(x -> torch.as_tensor(x).to(device = wrap.device, dtype = wrap.dtype).requires_grad_(true), wrap.params)),
-        map(x -> torch.as_tensor(PyReverseDims(x)).to(dtype = wrap.dtype, device = wrap.device).requires_grad_(true), args)...)
+        wrap.buffers, map(x -> torch.as_tensor(PyReverseDims(x)).to(dtype = wrap.dtype, device = wrap.device).requires_grad_(true), args)...)
     project = ProjectTo(args)
     function TorchModuleWrapper_pullback(Δ)
         torch_tangent_vals = torch_vjpfun(torch.as_tensor(PyReverseDims(Δ)).to(dtype = wrap.dtype, device = wrap.device))
         jlparams_tangents = map(x -> x.detach().numpy(), torch_tangent_vals[1])
-        args_tangents = project(map(x -> reversedims(x.detach().numpy()), torch_tangent_vals[2:end]))
-        return (Tangent{TorchModuleWrapper}(; torch_stateless_module = NoTangent(), dtype = NoTangent(), device = NoTangent(), params = jlparams_tangents), args_tangents...)
+        args_tangents = project(map(x -> reversedims(x.detach().numpy()), torch_tangent_vals[3:end]))
+        return (Tangent{TorchModuleWrapper}(; torch_stateless_module = NoTangent(), dtype = NoTangent(), device = NoTangent(), params = jlparams_tangents, buffers = NoTangent()), args_tangents...)
     end
     return reversedims(torch_primal.detach().numpy()), TorchModuleWrapper_pullback
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using SafeTestsets
 @safetestset "PyCallChainRules.jl" begin
     @safetestset "torch" begin
         include("test_pytorch.jl")
+        @safetestset "hub" begin
+            include("test_pytorch_hub.jl")
+        end
     end
     @safetestset "jax" begin
         include("test_jax.jl")

--- a/test/test_pytorch.jl
+++ b/test/test_pytorch.jl
@@ -15,11 +15,12 @@ end
 Random.seed!(42)
 ChainRulesTestUtils.rand_tangent(rng::Random.AbstractRNG, x::Ptr) = NoTangent()
 ChainRulesTestUtils.test_approx(::AbstractZero, x::PyObject, msg=""; kwargs...) = @test true
+ChainRulesTestUtils.test_approx(::AbstractZero, x::Tuple{}, msg=""; kwargs...) = @test true
 
 function ChainRulesTestUtils.FiniteDifferences.to_vec(x::TorchModuleWrapper) 
     params_vec, back = ChainRulesTestUtils.FiniteDifferences.to_vec(x.params)
     function TorchModuleWrapper_from_vec(params_vec)
-        TorchModuleWrapper(x.torch_stateless_module, x.dtype, x.device, back(params_vec))
+        TorchModuleWrapper(x.torch_stateless_module, x.dtype, x.device, back(params_vec), x.buffers)
     end
     return params_vec, TorchModuleWrapper_from_vec
 end


### PR DESCRIPTION
Larger pytorch models (especially on `torch.hub`) often have buffers as well as parameters. So, use those by default because models with no buffers would just have it empty.